### PR TITLE
setup: Avoid cyclic dependency during setup

### DIFF
--- a/pymycobot/__init__.py
+++ b/pymycobot/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
-from pymycobot.mycobot import MyCobot
-from pymycobot.generate import MycobotCommandGenerater
-from pymycobot.genre import Angle, Coord
+import os
+if os.environ.get("_MYCOBOT_VERSION_ONLY") != "1":
+    from pymycobot.mycobot import MyCobot
+    from pymycobot.generate import MycobotCommandGenerater
+    from pymycobot.genre import Angle, Coord
 
-__all__ = ["MyCobot", "MycobotCommandGenerater", "Angle", "Coord"]
+    __all__ = ["MyCobot", "MycobotCommandGenerater", "Angle", "Coord"]
 
 __version__ = "2.5.3"
 __author__ = "Zachary zhang"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 PYTHON_VERSION = sys.version_info[:2]
@@ -6,6 +7,7 @@ if (2, 7) != PYTHON_VERSION < (3, 5):
     sys.exit(1)
 
 import setuptools
+os.environ["_MYCOBOT_VERSION_ONLY"] = "1"
 import pymycobot
 
 if PYTHON_VERSION == (2, 7):


### PR DESCRIPTION
If `serial` is not installed, then `pip install` will fail trying
to import `serial`.

Relates #15