### PR TITLE
fix read serial data timeout

### DIFF
--- a/pymycobot/common.py
+++ b/pymycobot/common.py
@@ -204,7 +204,7 @@ def write(self, command, method=None):
             self.sock.sendall(str(command).encode())
         else:
             self.sock.sendall(bytes(command))
-        
+
         if len(command) > 3 and command[3] == 177:
             while True:
                 data = self.sock.recv(1024)
@@ -230,6 +230,7 @@ def write(self, command, method=None):
 
 
 def read(self):
+    time.sleep(0.1)
     if self._serial_port.inWaiting() > 0:
         data = self._serial_port.read(self._serial_port.inWaiting())
         self.log.debug("_read: {}".format(data))


### PR DESCRIPTION
测试TOF距离传感器，读取数据时未设置读取延迟，导致只能读取短距离数据，无法读取正常距离数据，增加读取延迟使读取正常。