### PR TITLE
adding cv2 as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyserial
 pytest
 flake8
+opencv-python 


### PR DESCRIPTION
Adding opencv as a dependency. I got an error when using the package for the first time that cv2 could not be found.