### PR TITLE
fix: Return type of sync_send_angles is int, should not use method chaining. 

### DIFF
--- a/demo/sync.py
+++ b/demo/sync.py
@@ -17,11 +17,16 @@ def test(mycobot):
     mycobot.sync_send_angles([100,50,0,0,70,160], 100)
     mycobot.sync_send_angles([-100,-50,0,0,-70,-160], 100)
     """
-    mycobot.sync_send_angles([0, 0, 0, 0, 0, 0], 100).sync_send_angles(
-        [100, 50, 0, 0, 70, 160], 100
-    ).sync_send_angles([-100, -50, 0, 0, -70, -160], 100).sync_send_angles(
-        reset, 100
-    ).set_free_mode()
+    # mycobot.sync_send_angles([0, 0, 0, 0, 0, 0], 100).sync_send_angles(
+    #     [100, 50, 0, 0, 70, 160], 100
+    # ).sync_send_angles([-100, -50, 0, 0, -70, -160], 100).sync_send_angles(
+    #     reset, 100
+    # ).set_free_mode()
+    # See: https://github.com/elephantrobotics/pymycobot/issues/144
+    mycobot.sync_send_angles([0, 0, 0, 0, 0, 0], 100)
+    mycobot.sync_send_angles([100, 50, 0, 0, 70, 160], 100)
+    mycobot.sync_send_angles([-100,-50, 0, 0, -70,-160], 100)
+    mycobot.set_free_mode(1)
 
     print("=== check end ===\n")
 


### PR DESCRIPTION
Return type of sync_send_angles is int, should not use method chaining.  See: [#144](https://github.com/AkagawaTsurunaki/pymycobot/issues/144)