### PR TITLE
test: 新增夹爪接口鲁棒性与故障注入测试套件 | Add mock-based robustness & fault-injection tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from pymycobot.mycobot import MyCobot
+
+@pytest.fixture
+def mock_serial_port():
+    """Mock 底层串口硬件交互，拦截对真实物理硬件的访问"""
+    with patch("serial.Serial") as mock_class:
+        mock_instance = MagicMock()
+        mock_class.return_value = mock_instance
+        
+        # 模拟串口处于开启状态
+        mock_instance.is_open = True
+        mock_instance.isOpen.return_value = True
+        
+        # 默认模拟硬件串口正常响应基础协议帧
+        mock_instance.read.return_value = b"\xfe\xfe\x04\x01\x01\xfa"
+        
+        yield mock_instance
+
+@pytest.fixture
+def mc_bot(mock_serial_port):
+    """初始化并返回绑定的被测 MyCobot 实例"""
+    bot = MyCobot("COM_VIRTUAL", 115200)
+    return bot


### PR DESCRIPTION
### 概述与目的 (Summary & Motivation)
本 PR 为机械外设/夹爪控制接口引入了一套基于 Mock 解耦物理硬件的 pytest 单元与容错测试套件，关联讨论议题 #264。
This PR introduces mock-based pytest unit and fault-injection tests for gripper control interfaces, linking to issue #264.

---

### 核心测试覆盖点 (Key Test Coverage)
1. **边界值验证 (Boundary Verification)**: 覆盖夹爪开合度与速度的合法边界（`[0, 100]` 与 `[1, 100]`）。
   Valid boundaries for `set_gripper_value` and speed arguments.
2. **负向鲁棒性 (Negative Robustness)**: 针对越界负数、超限数值及非法类型，验证前置参数拦截能力。
   Defensive checking against out-of-bounds inputs and invalid types.
3. **故障注入验证 (Fault Injection)**: 模拟通信超时（返回空字节 `b""`）与意外掉线（`SerialException`）。
   Simulating communication read timeouts and unexpected physical serial disconnection.
4. **脱离硬件解耦 (Hardware Decoupling)**: 基于 `unittest.mock` 对底层 `serial.Serial` 进行打桩拦截，支持纯 CI 环境自动化流水线运行。
   Uses `unittest.mock` to mock `serial.Serial`, enabling CI runs without physical robots.